### PR TITLE
use underscores as word separators in identifiers

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -1,5 +1,5 @@
 
-module "dns-for-failover" {
+module "dns_for_failover" {
   source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.1.0"
 
   app_name             = var.app_name

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ data "aws_region" "secondary" {
   provider = aws.secondary
 }
 
-module "custom-domains" {
+module "custom_domains" {
   source = "./modules/custom-domains"
 
   # NOTE: This value needs to match the name given to the API by Serverless.
@@ -26,13 +26,13 @@ module "custom-domains" {
   }
 }
 
-module "fail-over-cname" {
+module "fail_over_cname" {
   source = "./modules/fail-over-cname"
 
   aws_region                   = local.aws_region
   aws_region_secondary         = local.aws_region_secondary
   cloudflare_zone_name         = var.cloudflare_zone_name
-  primary_region_domain_name   = module.custom-domains.primary_region_domain_name
-  secondary_region_domain_name = module.custom-domains.secondary_region_domain_name
+  primary_region_domain_name   = module.custom_domains.primary_region_domain_name
+  secondary_region_domain_name = module.custom_domains.secondary_region_domain_name
   subdomain                    = var.app_name
 }

--- a/modules/custom-domains/main.tf
+++ b/modules/custom-domains/main.tf
@@ -1,5 +1,5 @@
 
-module "primary-region" {
+module "primary_region" {
   source = "./modules/certificate-and-domain"
 
   api_name              = var.api_name
@@ -10,9 +10,9 @@ module "primary-region" {
   providers = { aws = aws }
 }
 
-module "secondary-region" {
+module "secondary_region" {
   source     = "./modules/certificate-and-domain"
-  depends_on = [module.primary-region]
+  depends_on = [module.primary_region]
 
   api_name              = var.api_name
   api_stage             = var.api_stage

--- a/modules/custom-domains/outputs.tf
+++ b/modules/custom-domains/outputs.tf
@@ -1,8 +1,8 @@
 
 output "primary_region_domain_name" {
-  value = module.primary-region.regional_domain_name
+  value = module.primary_region.regional_domain_name
 }
 
 output "secondary_region_domain_name" {
-  value = module.secondary-region.regional_domain_name
+  value = module.secondary_region.regional_domain_name
 }

--- a/modules/fail-over-cname/main.tf
+++ b/modules/fail-over-cname/main.tf
@@ -8,7 +8,7 @@ data "cloudflare_zone" "this" {
   name = var.cloudflare_zone_name
 }
 
-resource "cloudflare_record" "public-cname" {
+resource "cloudflare_record" "public_cname" {
   comment = "For easy fail over. ${local.primary_region_summary} / ${local.secondary_region_summary}"
   name    = "${var.subdomain}.${var.cloudflare_zone_name}"
   proxied = true


### PR DESCRIPTION
### Changed (BREAKING)
- Changed identifiers to use underscores rather than hyphens. This is our internal standard as well as that of Hashicorp (and others).

Existing state resources can be moved using the `terraform state mv` command. ([Docs](https://developer.hashicorp.com/terraform/cli/commands/state/mv))