### PR TITLE
Do not assume API name follows a pattern

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -1,10 +1,11 @@
 
 module "dns_for_failover" {
-  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.1.0"
+  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.2.0"
 
-  app_name             = var.app_name
+  api_name             = var.api_name
   cloudflare_zone_name = var.cloudflare_zone_name
   serverless_stage     = var.serverless_stage
+  subdomain            = var.subdomain
 
   providers = {
     aws           = aws

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,6 @@
 
 module "dns_for_failover" {
-  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.2.0"
+  source = "github.com/silinternational/terraform-aws-serverless-api-dns-for-failover?ref=0.3.0"
 
   api_name             = var.api_name
   cloudflare_zone_name = var.cloudflare_zone_name

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,6 +1,6 @@
 
-variable "app_name" {
-  description = "Short name for the app (e.g. 'my-api'). Used as the subdomain."
+variable "api_name" {
+  description = "Short name of the API (as shown in AWS API Gateway). It probably consists of your Serverless service name and stage (e.g. either 'my-api-dev' or 'dev-my-api')."
   type        = string
 }
 
@@ -38,5 +38,10 @@ variable "cloudflare_zone_name" {
 
 variable "serverless_stage" {
   description = "Short name for the stage (aka environment): 'dev' or 'prod'"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "The subdomain for the CNAME record (e.g. 'my-api')"
   type        = string
 }

--- a/main.tf
+++ b/main.tf
@@ -13,11 +13,9 @@ data "aws_region" "secondary" {
 module "custom_domains" {
   source = "./modules/custom-domains"
 
-  # NOTE: This value needs to match the name given to the API by Serverless.
-  api_name = "${var.serverless_stage}-${var.app_name}"
-
+  api_name              = var.api_name
   api_stage             = var.serverless_stage
-  certificate_subdomain = var.app_name
+  certificate_subdomain = var.subdomain
   cloudflare_zone_name  = var.cloudflare_zone_name
 
   providers = {
@@ -34,5 +32,5 @@ module "fail_over_cname" {
   cloudflare_zone_name         = var.cloudflare_zone_name
   primary_region_domain_name   = module.custom_domains.primary_region_domain_name
   secondary_region_domain_name = module.custom_domains.secondary_region_domain_name
-  subdomain                    = var.app_name
+  subdomain                    = var.subdomain
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -2,9 +2,10 @@
 module "test" {
   source = "../"
 
-  app_name             = "my-api"
+  api_name             = "my-api-dev"
   cloudflare_zone_name = "example.com"
   serverless_stage     = "dev"
+  subdomain            = "my-api"
 
   providers = {
     aws           = aws

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 
-variable "app_name" {
-  description = "Short name for the app (e.g. 'my-api'). Used as the subdomain."
+variable "api_name" {
+  description = "Short name of the API (as shown in AWS API Gateway). It probably consists of your Serverless service name and stage (e.g. either 'my-api-dev' or 'dev-my-api')."
   type        = string
 }
 
@@ -11,5 +11,10 @@ variable "cloudflare_zone_name" {
 
 variable "serverless_stage" {
   description = "Short name for the stage (aka environment): 'dev' or 'prod'"
+  type        = string
+}
+
+variable "subdomain" {
+  description = "The subdomain for the CNAME record (e.g. 'my-api')"
   type        = string
 }


### PR DESCRIPTION
### Changed (BREAKING)
- Get the API Name from a variable, instead of assuming we can guess it
  * In some cases it is "stage-service" (e.g. "dev-my-api"), but in other cases it is "service-stage" (e.g. "my-api-dev"). Rather than making assumptions, just have the code using this module provide us with the API Name. This also required asking for the desired subdomain separately, since previously we just used the app name for that, and this change replaces that `app_name` variable with the `api_name` and `subdomain` variables.