### PR TITLE
output the primary and secondary region DNS for convenience

### DIFF
--- a/modules/fail-over-cname/outputs.tf
+++ b/modules/fail-over-cname/outputs.tf
@@ -1,5 +1,13 @@
+output "primary_region_domain_name" {
+  value = var.primary_region_domain_name
+}
+
 output "primary_region_summary" {
   value = local.primary_region_summary
+}
+
+output "secondary_region_domain_name" {
+  value = var.primary_region_domain_name
 }
 
 output "secondary_region_summary" {

--- a/modules/fail-over-cname/outputs.tf
+++ b/modules/fail-over-cname/outputs.tf
@@ -1,0 +1,7 @@
+output "primary_region_summary" {
+  value = local.primary_region_summary
+}
+
+output "secondary_region_summary" {
+  value = local.secondary_region_summary
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,14 @@
 
+output "primary_region_domain_name" {
+  value = module.fail_over_cname.primary_region_domain_name
+}
+
 output "primary_region_summary" {
   value = module.fail_over_cname.primary_region_summary
+}
+
+output "secondary_region_domain_name" {
+  value = module.fail_over_cname.primary_region_domain_name
 }
 
 output "secondary_region_summary" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,1 +1,8 @@
 
+output "primary_region_summary" {
+  value = module.fail_over_cname.primary_region_summary
+}
+
+output "secondary_region_summary" {
+  value = module.fail_over_cname.secondary_region_summary
+}


### PR DESCRIPTION
### Added
- New outputs: `primary_region_domain_name`, `primary_region_summary`, `secondary_region_domain_name`, and `secondary_region_summary`