### PR TITLE
experiment to see whether the `.validation_id` should be included here

### DIFF
--- a/modules/custom-domains/modules/certificate-and-domain/main.tf
+++ b/modules/custom-domains/modules/certificate-and-domain/main.tf
@@ -13,7 +13,7 @@ module "certificate" {
 
 module "domain" {
   source     = "github.com/silinternational/terraform-aws-api-gateway-custom-domain?ref=0.2.0"
-  depends_on = [module.certificate.validation_id]
+  depends_on = [module.certificate]
 
   api_name        = var.api_name
   certificate_arn = module.certificate.certificate_arn


### PR DESCRIPTION
I see examples of `depends_on` using the model name alone, not an output of the module. Hopefully this fixes the run apply failure due to the certificate not being ready before the API Gateway resources are created.