### PR TITLE
only use the subdomain when creating a DNS record

### DIFF
--- a/modules/fail-over-cname/main.tf
+++ b/modules/fail-over-cname/main.tf
@@ -10,7 +10,7 @@ data "cloudflare_zone" "this" {
 
 resource "cloudflare_record" "public_cname" {
   comment = "For easy fail over. ${local.primary_region_summary} / ${local.secondary_region_summary}"
-  name    = "${var.subdomain}.${var.cloudflare_zone_name}"
+  name    = var.subdomain
   proxied = true
   ttl     = 1 # ttl must be set to 1 when proxied is true
   type    = "CNAME"


### PR DESCRIPTION
### Changed
- Use only the subdomain when specifying the name of a DNS record. It works either way, but it seems the usual way is to not include the domain (zone). 

_Note: this could actually be significant since the specified name remains in the Cloudflare database even though the Cloudflare dashboard only shows the subdomain. I found this when I used the Cloudflare API to query DNS records. It could not find the record by specifying only the subdomain when the record was created using the full hostname (subdomain+domain)._