### PR TITLE
Allow CNAME proxy status to be configured

### DIFF
--- a/example/variables.tf
+++ b/example/variables.tf
@@ -26,6 +26,12 @@ variable "aws_region_secondary" {
   type        = string
 }
 
+variable "cloudflare_proxy_status" {
+  description = "Set the Cloudflare CNAME proxy status"
+  type        = bool
+  default     = true
+}
+
 variable "cloudflare_token" {
   description = "Cloudflare limited access API token"
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ module "fail_over_cname" {
 
   aws_region                   = local.aws_region
   aws_region_secondary         = local.aws_region_secondary
+  cloudflare_proxy_status      = var.cloudflare_proxy_status
   cloudflare_zone_name         = var.cloudflare_zone_name
   primary_region_domain_name   = module.custom_domains.primary_region_domain_name
   secondary_region_domain_name = module.custom_domains.secondary_region_domain_name

--- a/modules/fail-over-cname/main.tf
+++ b/modules/fail-over-cname/main.tf
@@ -11,7 +11,7 @@ data "cloudflare_zone" "this" {
 resource "cloudflare_record" "public_cname" {
   comment = "For easy fail over. ${local.primary_region_summary} / ${local.secondary_region_summary}"
   name    = var.subdomain
-  proxied = true
+  proxied = var.cloudflare_proxy_status
   ttl     = 1 # ttl must be set to 1 when proxied is true
   type    = "CNAME"
   value   = var.primary_region_domain_name

--- a/modules/fail-over-cname/variables.tf
+++ b/modules/fail-over-cname/variables.tf
@@ -9,6 +9,12 @@ variable "aws_region_secondary" {
   type        = string
 }
 
+variable "cloudflare_proxy_status" {
+  description = "Set the Cloudflare CNAME proxy status"
+  type        = bool
+  default     = true
+}
+
 variable "cloudflare_zone_name" {
   description = "The Cloudflare zone (aka domain) name"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "cloudflare_zone_name" {
   type        = string
 }
 
+variable "cloudflare_proxy_status" {
+  description = "Set the Cloudflare CNAME proxy status"
+  type        = bool
+  default     = true
+}
+
 variable "serverless_stage" {
   description = "Short name for the stage (aka environment): 'dev' or 'prod'"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -4,15 +4,15 @@ variable "api_name" {
   type        = string
 }
 
-variable "cloudflare_zone_name" {
-  description = "Cloudflare zone (aka domain) name"
-  type        = string
-}
-
 variable "cloudflare_proxy_status" {
   description = "Set the Cloudflare CNAME proxy status"
   type        = bool
   default     = true
+}
+
+variable "cloudflare_zone_name" {
+  description = "Cloudflare zone (aka domain) name"
+  type        = string
 }
 
 variable "serverless_stage" {


### PR DESCRIPTION
Sherlock was losing its request headers when proxy status was true but working properly when it was false.