### PR TITLE
Wait for certificate to be issued before trying to use it

### DIFF
--- a/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/main.tf
+++ b/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/main.tf
@@ -4,7 +4,8 @@ locals {
 }
 
 module "certificate" {
-  source = "github.com/silinternational/terraform-aws-acm-certificate?ref=0.2.0"
+  source  = "silinternational/acm-certificate/aws"
+  version = "0.2.1"
 
   certificate_domain_name = local.full_domain_name
   cloudflare_zone_name    = var.cloudflare_zone_name


### PR DESCRIPTION
### Fixed
- Wait for certificate to be issued before trying to use it
  * Here are the [release notes for acm-certificate 0.2.1](https://github.com/silinternational/terraform-aws-acm-certificate/releases/tag/0.2.1)