### PR TITLE
Restrict Cloudflare version to  < 4.39.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @silinternational/tf-devs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+### Added
+-
+
+### Changed
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+-
+
+### Security
+-

--- a/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/main.tf
+++ b/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/main.tf
@@ -3,21 +3,55 @@ locals {
   full_domain_name = "${var.certificate_subdomain}.${var.cloudflare_zone_name}"
 }
 
-module "certificate" {
-  source  = "silinternational/acm-certificate/aws"
-  version = "0.2.2"
-
-  certificate_domain_name = local.full_domain_name
-  cloudflare_zone_name    = var.cloudflare_zone_name
-  create_dns_validation   = var.create_dns_validation
-}
-
 module "domain" {
   source     = "github.com/silinternational/terraform-aws-api-gateway-custom-domain?ref=0.2.0"
-  depends_on = [module.certificate]
+  depends_on = [aws_acm_certificate_validation.this]
 
   api_name        = var.api_name
-  certificate_arn = module.certificate.certificate_arn
+  certificate_arn = aws_acm_certificate_validation.this.certificate_arn
   domain_name     = local.full_domain_name
   stage           = var.api_stage
+}
+
+
+data "cloudflare_zone" "this" {
+  name = var.cloudflare_zone_name
+}
+
+resource "aws_acm_certificate" "this" {
+  domain_name       = local.full_domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+moved {
+  from = module.certificate.aws_acm_certificate.this
+  to   = aws_acm_certificate.this
+}
+
+resource "cloudflare_record" "validation" {
+  count = var.create_dns_validation ? 1 : 0
+
+  name    = tolist(aws_acm_certificate.this.domain_validation_options)[0].resource_record_name
+  value   = tolist(aws_acm_certificate.this.domain_validation_options)[0].resource_record_value
+  type    = tolist(aws_acm_certificate.this.domain_validation_options)[0].resource_record_type
+  zone_id = data.cloudflare_zone.this.id
+  proxied = false
+}
+
+moved {
+  from = module.certificate.cloudflare_record.validation
+  to   = cloudflare_record.validation
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  certificate_arn = aws_acm_certificate.this.arn
+}
+
+moved {
+  from = module.certificate.aws_acm_certificate_validation.this
+  to   = aws_acm_certificate_validation.this
 }

--- a/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/versions.tf
+++ b/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/versions.tf
@@ -4,12 +4,10 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4"
+      source = "hashicorp/aws"
     }
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = ">= 2"
+      source = "cloudflare/cloudflare"
     }
   }
 }

--- a/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/versions.tf
+++ b/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/versions.tf
@@ -4,11 +4,11 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 4"
     }
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = ">= 4"
+      source = "cloudflare/cloudflare"
 
       // 4.39.0 and later versions deprecated cloudflare_record.value
       // constraining to earlier versions while waiting for version 5 to mature

--- a/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/versions.tf
+++ b/modules/api-gateway-domains-and-certs/modules/certificate-and-domain/versions.tf
@@ -7,7 +7,12 @@ terraform {
       source = "hashicorp/aws"
     }
     cloudflare = {
-      source = "cloudflare/cloudflare"
+      source  = "cloudflare/cloudflare"
+      version = ">= 4"
+
+      // 4.39.0 and later versions deprecated cloudflare_record.value
+      // constraining to earlier versions while waiting for version 5 to mature
+      version = ">= 2.0.0, < 4.39.0"
     }
   }
 }

--- a/modules/api-gateway-domains-and-certs/versions.tf
+++ b/modules/api-gateway-domains-and-certs/versions.tf
@@ -4,15 +4,13 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4"
+      source = "hashicorp/aws"
       configuration_aliases = [
         aws.secondary,
       ]
     }
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = ">= 2"
+      source = "cloudflare/cloudflare"
     }
   }
 }

--- a/modules/fail-over-cnames/versions.tf
+++ b/modules/fail-over-cnames/versions.tf
@@ -4,8 +4,11 @@ terraform {
 
   required_providers {
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = ">= 2"
+      source = "cloudflare/cloudflare"
+
+      // 4.39.0 and later versions deprecated cloudflare_record.value
+      // constraining to earlier versions while waiting for version 5 to mature
+      version = ">= 2.0.0, < 4.39.0"
     }
   }
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -27,12 +27,10 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 4.0"
+      source = "hashicorp/aws"
     }
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = ">= 2.0.0, < 4.0.0"
+      source = "cloudflare/cloudflare"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,15 +4,13 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4"
+      source = "hashicorp/aws"
       configuration_aliases = [
         aws.secondary,
       ]
     }
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = ">= 2"
+      source = "cloudflare/cloudflare"
     }
   }
 }


### PR DESCRIPTION
[IDP-1251](https://itse.youtrack.cloud/issue/IDP-1251) Update MFA Terraform Cloudflare provider to 4.x

---

### Changed
- Restrict Cloudflare version to `< 4.39.0` to avoid deprecation notices while waiting for version 5 to stabilize.
- Fold in the certificate module to define the resources in this repository.

### Removed
- Removed unnecessary version constraints where no local resources are defined. That is, no resources defined except in sub-modules.

### Added
- Added CODEOWNERS and PR template